### PR TITLE
fix: do not delete signature_id between event uses

### DIFF
--- a/cef_formatter.go
+++ b/cef_formatter.go
@@ -33,7 +33,6 @@ func (f formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	data := entry.Data
 	if _, ok := entry.Data[KeySignatureID]; ok {
 		sigId = fmt.Sprint(data[KeySignatureID])
-		delete(data, KeySignatureID)
 	}
 	name := entry.Message
 	if !f.DisableTimestamp {
@@ -60,6 +59,9 @@ func (f formatter) Format(entry *logrus.Entry) ([]byte, error) {
 func (f formatter) formatData(fields logrus.Fields) (string, error) {
 	keyVals := make([]string, 0)
 	for k, v := range fields {
+		if k == KeySignatureID {
+			continue
+		}
 		vKind := reflect.TypeOf(v).Kind()
 		vFormat := ""
 		if vKind == reflect.Struct ||

--- a/cef_formatter_test.go
+++ b/cef_formatter_test.go
@@ -2,6 +2,7 @@ package cef_test
 
 import (
 	"bytes"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -38,6 +39,17 @@ var _ = Describe("CefFormatter", func() {
 				logger.Info("test")
 
 				Expect(buf.String()).To(Equal("CEF:0|arthurhlt|logrus-cef|1.0|test|test|0|\n"))
+			})
+		})
+		When("Reusing an event", func() {
+			It("should not clear the signature_id", func() {
+				entry := logger.WithField(KeySignatureID, "my-signature")
+
+				entry.Info("test.1")
+				Expect(buf.String()).To(ContainSubstring("CEF:0|arthurhlt|logrus-cef|1.0|my-signature|test.1|0|rt="))
+
+				entry.Info("test.2")
+				Expect(buf.String()).To(ContainSubstring("CEF:0|arthurhlt|logrus-cef|1.0|my-signature|test.2|0|rt="))
 			})
 		})
 		When("With field", func() {


### PR DESCRIPTION
First off, thanks for making this package! :)

I hit a bug when saving an event to a variable and using it to report an event beginning and ending. When the end log line is emitted the signature ID disappears.

I've made a minor edit to skip the value while formatting rather than deleting it outright, this way if an event is reused it still formats correctly:

```
event := eventLogger.WithField(cef.KeySignatureID, SomeSignature)
event.Info("started")
event.Info("stopped") // signature will not be deleted and replaced with message
```